### PR TITLE
Enable linting, use flake8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "python.pythonPath": "env\\Scripts\\python.exe"
+  "python.pythonPath": "env\\Scripts\\python.exe",
+  "python.linting.pylintEnabled": false,
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true
 }


### PR DESCRIPTION
After merging this PR, VS Code should pop up an "error" suggesting that you install `flake8`:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/6334517/79392074-f511db00-7f2f-11ea-9883-39ad83ede8ec.png">

Click "Install" and VS Code should automatically install that package in your virtual environment.  I'm very happy to see you're using a virtual environment!

For more info on VS Code and Python linting, check out VS Code's [docs](https://code.visualstudio.com/docs/python/linting#_run-linting)